### PR TITLE
Shebang usage improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 
 script:
   - flake8 setup.py conda_shell
-  - pytest --verbose --cov=conda_shell --cov-report term-missing tests
+  - pytest --cov=conda_shell --cov-report term-missing tests
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 
 script:
   - flake8 setup.py conda_shell
-  - pytest --cov=conda_shell --cov-report term-missing tests
+  - pytest --cov=conda_shell --cov-report term-missing --verbose tests
 
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Once the [requirements](#requirements) are satisified, `conda-shell` may be inst
 ```
 git clone https://github.com/gbrener/conda-shell.git
 cd conda-shell
-python setup.py develop
+python setup.py develop --no-deps
 ```
 
 ## Usage

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,7 +27,7 @@ test:
     - pytest-cov
 
   commands:
-    - pytest --cov=conda_shell --cov-report term-missing -v -x $SP_DIR/tests
+    - pytest --cov=conda_shell --cov-report term-missing -x $SP_DIR/tests
     - which conda-shell
 
 about:

--- a/conda_shell/conda_cli.py
+++ b/conda_shell/conda_cli.py
@@ -103,8 +103,8 @@ class CondaCLI(object):
         """
         sys.path.append(self.conda_sp_dpath)
         sys.path.extend(glob.glob(
-            os.path.join(self.conda_sp_dpath, 'pycosat*'))
-        )
+            os.path.join(self.conda_sp_dpath, 'pycosat*')
+        ))
 
         for modname in ('ruamel', 'ruamel.yaml', 'ruamel.yaml.comments',
                         'ruamel.yaml.scanner'):

--- a/conda_shell/interactive.py
+++ b/conda_shell/interactive.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
+import sys
 import atexit
 import cmd
 import subprocess

--- a/conda_shell/interactive.py
+++ b/conda_shell/interactive.py
@@ -46,7 +46,7 @@ class InteractiveShell(cmd.Cmd):
 
     def default(self, line):  # pragma: no cover
         if line == 'EOF':
-            print('\nExiting conda-shell...')
+            print('\nExiting conda-shell...', file=sys.stderr)
             return True
         subprocess.call(shlex.split(line.rstrip()),
                         env=self.env,

--- a/conda_shell/main.py
+++ b/conda_shell/main.py
@@ -151,7 +151,7 @@ def env_has_pkgs(env_dpath, cmds, cli):
     return True
 
 
-def run_cmds_in_env(cmds, cli):
+def run_cmds_in_env(cmds, cli, argv):
     """Execute the cmds (list of argparse.Namespace objects) in a temporary
     conda environment. Interactive shell functionality is a REPL. Shebang lines
     are handled the same way we handle running arbitrary commands with --run:
@@ -188,7 +188,7 @@ def run_cmds_in_env(cmds, cli):
         for args in cmds:
             if env_to_reuse is not None:
                 args.name = env_to_reuse
-        subprocess.call(shlex.split(cmds[0].run) + sys.argv[2:],
+        subprocess.call(shlex.split(cmds[0].run) + argv[2:],
                         env=env_vars,
                         universal_newlines=True)
     else:
@@ -214,4 +214,4 @@ def main(argv):
         if cmds[0].name is None:
             cmds[0].name = rand_env_name()
 
-    run_cmds_in_env(cmds, cli)
+    run_cmds_in_env(cmds, cli, argv)

--- a/conda_shell/main.py
+++ b/conda_shell/main.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
+import sys
 import re
 import subprocess
 import uuid
@@ -165,7 +166,8 @@ def run_cmds_in_env(cmds, cli):
     for env_dpath in env_dpaths:
         if env_has_pkgs(env_dpath, cmds, cli):
             env_to_reuse = os.path.basename(env_dpath)
-            print('Reusing shell env "{}"...'.format(env_to_reuse))
+            print('Reusing shell env "{}"...'.format(env_to_reuse),
+                  file=sys.stderr)
             break
 
     # Existing environment was not found, so create a fresh one.
@@ -186,10 +188,9 @@ def run_cmds_in_env(cmds, cli):
         for args in cmds:
             if env_to_reuse is not None:
                 args.name = env_to_reuse
-        subprocess.check_call(shlex.split(cmds[0].run),
-                              env=env_vars,
-                              stderr=subprocess.STDOUT,
-                              universal_newlines=True)
+        subprocess.call(shlex.split(cmds[0].run) + sys.argv[2:],
+                        env=env_vars,
+                        universal_newlines=True)
     else:
         prompt = '[{}]: '.format(os.path.basename(env_dpath))
         InteractiveShell(prompt, env=env_vars).cmdloop()

--- a/conda_shell/main.py
+++ b/conda_shell/main.py
@@ -190,9 +190,7 @@ def run_cmds_in_env(cmds, cli):
                 args.name = env_to_reuse
         subprocess.call(shlex.split(cmds[0].run) + sys.argv[2:],
                         env=env_vars,
-                        universal_newlines=True,
-                        stdout=sys.stdout,
-                        stderr=sys.stderr)
+                        universal_newlines=True)
     else:
         prompt = '[{}]: '.format(os.path.basename(env_dpath))
         InteractiveShell(prompt, env=env_vars).cmdloop()

--- a/conda_shell/main.py
+++ b/conda_shell/main.py
@@ -190,7 +190,9 @@ def run_cmds_in_env(cmds, cli):
                 args.name = env_to_reuse
         subprocess.call(shlex.split(cmds[0].run) + sys.argv[2:],
                         env=env_vars,
-                        universal_newlines=True)
+                        universal_newlines=True,
+                        stdout=sys.stdout,
+                        stderr=sys.stderr)
     else:
         prompt = '[{}]: '.format(os.path.basename(env_dpath))
         InteractiveShell(prompt, env=env_vars).cmdloop()

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
 name: conda-shell
 dependencies:
   - pyyaml
-  - flake8
   - pytest
   - pytest-cov
   - six
   - mock
+  - flake8
   - conda-forge::coveralls

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import subprocess
 
 import yaml
+import six
 from setuptools import setup, find_packages
 from conda_shell import __version__
 
@@ -11,6 +12,10 @@ with open('environment.yml') as env_fd:
     for dep in deps:
         if '::' in dep:
             dep = dep.split('::')[1]
+        if (dep.startswith('pytest') or
+                dep in ('coveralls', 'flake8') or
+                (not six.PY2 and dep == 'mock')):
+            continue
         install_requires.append(dep)
 
 git_cmd = ['git', 'remote', 'get-url', 'origin']

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,7 +25,7 @@ class TestMain(object):
             ['conda-shell', 'python=3.5', 'numpy=1.13', '--run', 'python -V']
         )
         out, err = capfd.readouterr()
-        assert 'Python 3.5' in out
+        assert 'Python 3.5' in err
 
     def test_in_shebang(self, remove_shell_envs, capfd):
         """Test that conda-shell works from within a shebang line."""


### PR DESCRIPTION
Preserve stdout and stderr from script when `conda-shell` is called from a script's shebang line. Also, forward the script arguments (from `sys.argv`) to the full interpreted command.